### PR TITLE
Fix: fixed error messages when opening non existing files

### DIFF
--- a/matlab_code/patternFxns/buildAllosteric.m
+++ b/matlab_code/patternFxns/buildAllosteric.m
@@ -22,9 +22,8 @@ function buildAllosteric(metList,reactionName,negEffectors,posEffectors)
 currentPath = regexp(mfilename('fullpath'), '(.*)[/\\\\]', 'match');
 filepath = fullfile(currentPath{1}, '..', '..', 'temp', 'reactions', [reactionName,'.m']);
 
-try
-    fid = fopen(filepath, 'w'); 
-catch
+fid = fopen(filepath, 'w'); 
+if fid == -1
     error(['File not found: ', filepath, ...
             newline, ...
            'Please make sure the folder ', fullfile(currentPath{1}, '..', '..', 'temp', 'reactions'), ...

--- a/matlab_code/patternFxns/buildDiffusion.m
+++ b/matlab_code/patternFxns/buildDiffusion.m
@@ -21,9 +21,8 @@ reactionName = [reactionName,num2str(strucIdx)];
 currentPath = regexp(mfilename('fullpath'), '(.*)[/\\\\]', 'match');
 filepath = fullfile(currentPath{1}, '..', '..', 'temp', 'reactions', [reactionName,'.m']);
 
-try
-    fid = fopen(filepath, 'w'); 
-catch
+fid = fopen(filepath, 'w'); 
+if fid == -1
     error(['File not found: ', filepath, ...
             newline, ...
            'Please make sure the folder ', fullfile(currentPath{1}, '..', '..', 'temp'), ...

--- a/matlab_code/patternFxns/buildFixedExchange.m
+++ b/matlab_code/patternFxns/buildFixedExchange.m
@@ -21,9 +21,8 @@ reactionName = [reactionName,num2str(strucIdx)];
 currentPath = regexp(mfilename('fullpath'), '(.*)[/\\\\]', 'match');
 filepath = fullfile(currentPath{1}, '..', '..', 'temp', 'reactions', [reactionName,'.m']);
 
-try
-    fid = fopen(filepath, 'w'); 
-catch
+fid = fopen(filepath, 'w'); 
+if fid == -1
     error(['File not found: ', filepath, ...
             newline, ...
            'Please make sure the folder ', fullfile(currentPath{1}, '..', '..', 'temp'), ...

--- a/matlab_code/patternFxns/buildFreeExchange.m
+++ b/matlab_code/patternFxns/buildFreeExchange.m
@@ -21,9 +21,8 @@ reactionName = [reactionName,num2str(strucIdx)];
 currentPath = regexp(mfilename('fullpath'), '(.*)[/\\\\]', 'match');
 filepath = fullfile(currentPath{1}, '..', '..', 'temp', 'reactions', [reactionName,'.m']);
 
-try
-    fid = fopen(filepath, 'w'); 
-catch
+fid = fopen(filepath, 'w'); 
+if fid == -1
     error(['File not found: ', filepath, ...
             newline, ...
            'Please make sure the folder ', fullfile(currentPath{1}, '..', '..', 'temp'), ...

--- a/matlab_code/patternFxns/buildKineticFxn.m
+++ b/matlab_code/patternFxns/buildKineticFxn.m
@@ -32,9 +32,8 @@ freeVars   = [ensemble.mets(metsActive);ensemble.rxns(enzActive)];              
 currentPath = regexp(mfilename('fullpath'), '(.*)[/\\\\]', 'match');
 filepath = fullfile(currentPath{1}, '..', '..', 'reactions', [ensemble.description, '_', num2str(strucIdx)], [kineticFxn,'.m']);
 
-try
-    fid = fopen(filepath, 'w'); 
-catch
+fid = fopen(filepath, 'w'); 
+if fid == -1
     error(['File not found: ', filepath, ...
            newline, ...
            'Please make sure the folder ', fullfile(currentPath{1}, '..', '..', 'reactions'), ...

--- a/matlab_code/patternFxns/buildMassAction.m
+++ b/matlab_code/patternFxns/buildMassAction.m
@@ -22,9 +22,8 @@ reactionName = [reactionName,num2str(strucIdx)];
 currentPath = regexp(mfilename('fullpath'), '(.*)[/\\\\]', 'match');
 filepath = fullfile(currentPath{1}, '..', '..', 'temp', 'reactions', [reactionName,'.m']);
 
-try
-    fid = fopen(filepath, 'w'); 
-catch
+fid = fopen(filepath, 'w'); 
+if fid == -1
     error(['File not found: ', filepath, ...
             newline, ...
            'Please make sure the folder ', fullfile(currentPath{1}, '..', '..', 'temp'), ...

--- a/matlab_code/patternFxns/buildOdeFxn.m
+++ b/matlab_code/patternFxns/buildOdeFxn.m
@@ -23,18 +23,16 @@ function buildOdeFxn(ensemble, kineticFxn, strucIdx)
 currentPath = regexp(mfilename('fullpath'), '(.*)[/\\\\]', 'match');
 filepath = fullfile(currentPath{1}, '..', '..', 'reactions', [ensemble.description, '_', num2str(strucIdx)], [kineticFxn,'.m']);
 
-try
-    fIn = fopen(filepath);
-catch
+fIn = fopen(filepath);
+if fIn == -1
     error(['File not found: ', filepath, ...
            newline, ...
            'Please make sure the folder ', fullfile(currentPath{1}, '..', '..', 'reactions'), ...
            ' exists.']) ; 
 end
 
-try
-    fOut = fopen([filepath(1:(end-2)), '_ode.m'], 'w');
-catch
+fOut = fopen([filepath(1:(end-2)), '_ode.m'], 'w');
+if fOut == -1
     error(['File not found: ', [filepath(1:(end-2)), '_ode.m'], ...
            newline, ...
            'Please make sure the folder ', fullfile(currentPath{1}, '..', '..', 'reactions'), ...

--- a/matlab_code/patternFxns/buildReaction.m
+++ b/matlab_code/patternFxns/buildReaction.m
@@ -28,9 +28,8 @@ function buildReaction(state,rateList,metList,numTerm,prodNum,reactionName, prom
 currentPath = regexp(mfilename('fullpath'), '(.*)[/\\\\]', 'match');
 filepath = fullfile(currentPath{1}, '..', '..', 'temp', 'reactions', [reactionName,'.m']);
 
-try
-    fid = fopen(filepath, 'w'); 
-catch
+fid = fopen(filepath, 'w'); 
+if fid == -1
     error(['File not found: ', filepath, ...
            newline, ...
           'Please make sure the folder ', fullfile(currentPath{1}, '..', '..', 'temp'), ...


### PR DESCRIPTION
Before opening files was within a try/catch block.
However, matlab doesn't crash when the file to be
opened doesn't exist. Instead it returns -1, so now
i check for that and thrown an error, instead
of expecting an error.