### PR TITLE
Tests: fixed exportSBML test

### DIFF
--- a/matlab_code/tests/ensembleFxns/exportSBMLTest.m
+++ b/matlab_code/tests/ensembleFxns/exportSBMLTest.m
@@ -33,7 +33,9 @@ classdef exportSBMLTest < matlab.unittest.TestCase
             
             % Need to skip Simbiology version in the xml file, otherwise
             % the test will fail for different versions.
-            testCase.verifyEqual(trueRes(250:end), SBMLres(250:end));
+            indTrueRes = strfind(trueRes, '<model id=');
+            indRes = strfind(SBMLres, '<model id=');
+            testCase.verifyEqual(trueRes(indTrueRes:end), SBMLres(indRes:end));
         end
        
         
@@ -58,7 +60,9 @@ classdef exportSBMLTest < matlab.unittest.TestCase
             
             % Need to skip Simbiology version in the xml file, otherwise
             % the test will fail for different versions.       
-            testCase.verifyEqual(trueRes(250:end), SBMLres(250:end));
+            indTrueRes = strfind(trueRes, '<model id=');
+            indRes = strfind(SBMLres, '<model id=');
+            testCase.verifyEqual(trueRes(indTrueRes:end), SBMLres(indRes:end));
         end
         
     end

--- a/matlab_code/tests/ensembleFxns/testFiles/trueRes_toy_model1_allosteric2_1.xml
+++ b/matlab_code/tests/ensembleFxns/testFiles/trueRes_toy_model1_allosteric2_1.xml
@@ -2,7 +2,7 @@
 <sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4">
   <annotation>
     <SimBiology xmlns="http://www.mathworks.com">
-      <Version Major="5" Minor="10" Point="0"/>
+      <Version Major="5" Minor="9" Point="0"/>
     </SimBiology>
   </annotation>
   <model id="toy_model1_allosteric2" name="toy_model1_allosteric2">

--- a/matlab_code/tests/ensembleFxns/testFiles/trueRes_toy_model1_no_promiscuous2_1.xml
+++ b/matlab_code/tests/ensembleFxns/testFiles/trueRes_toy_model1_no_promiscuous2_1.xml
@@ -2,7 +2,7 @@
 <sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" version="4">
   <annotation>
     <SimBiology xmlns="http://www.mathworks.com">
-      <Version Major="5" Minor="10" Point="0"/>
+      <Version Major="5" Minor="9" Point="0"/>
     </SimBiology>
   </annotation>
   <model id="toy_model1_no_promiscuous2" name="toy_model1_no_promiscuous2">


### PR DESCRIPTION
The version of the SimBiology toolbox used to
export the model into SBML is included in the
SBML file, thus it needs to be addressed
when comparing the result of the function to
the "true" SBML file, otherwise once the
SimBiology version changes, the tests fail.