### PR TITLE
Add check for K lower limit in TMFA

### DIFF
--- a/matlab_code/ensembleFxns/computeGibbsFreeEnergyRanges.m
+++ b/matlab_code/ensembleFxns/computeGibbsFreeEnergyRanges.m
@@ -248,7 +248,7 @@ while fluxdGInconsistent
             end
 
         else
-            if K >= 1
+            if K >=max(abs(v_range), [], 'all') && K >= max(abs(DGr_range), [], 'all')
                 n = log10(K);
                 K = 10^(n-1);
                 continue

--- a/matlab_code/ensembleFxns/findIssuesWithTMFA.m
+++ b/matlab_code/ensembleFxns/findIssuesWithTMFA.m
@@ -43,7 +43,7 @@ function findIssuesWithTMFA(ensemble,model,DGf_std_min,DGf_std_max,vmin,vmax,xmi
 [metsList, metsBoundaryList] = findProblematicMetabolites(ensemble,DGf_std_min,DGf_std_max,vmin,vmax,xmin,xmax,ineqConstraints,K,RT,delta,M,tol);
 [rxnsList, rxnsBoundaryList] = findProblematicReactions(ensemble,DGf_std_min,DGf_std_max,vmin,vmax,xmin,xmax,ineqConstraints,K,RT,delta,M,tol);
 
-while isempty(metsList) && isempty(rxnsList) && K >= 1
+while isempty(metsList) && isempty(rxnsList) && K >= max(abs(vmax), [], 'all')
     n = log10(K);
     K = 10^(n-1);
     [metsList, metsBoundaryList] = findProblematicMetabolites(ensemble,DGf_std_min,DGf_std_max,vmin,vmax,xmin,xmax,ineqConstraints,K,RT,delta,M,tol);

--- a/matlab_code/tests/ensembleFxns/loadEnsembleStructureTest.m
+++ b/matlab_code/tests/ensembleFxns/loadEnsembleStructureTest.m
@@ -64,7 +64,8 @@ classdef loadEnsembleStructureTest < matlab.unittest.TestCase
             
             trueRes = trueRes.ensemble;
             trueRes.sampler = 'GRASP';
-             
+                       
+            
             testCase.verifyThat(ensemble, matlab.unittest.constraints.IsEqualTo(trueRes, ...
                 'Within', matlab.unittest.constraints.RelativeTolerance(1e-4)))
         end
@@ -207,11 +208,8 @@ classdef loadEnsembleStructureTest < matlab.unittest.TestCase
             trueRes = load(fullfile(testCase.currentPath{1}, 'testFiles', 'trueResLoadEnsemble_toy_model4.mat'));
             trueRes = trueRes.ensemble;
 
-            trueRes.sampler = 'GRASP';
-
-            ensemble = rmfield(ensemble, 'tolerance');
-            trueRes = rmfield(trueRes, 'tolerance');
-            trueRes = rmfield(trueRes, 'alphaAlive');            
+            trueRes.sampler = 'GRASP';   
+            
             testCase.verifyThat(ensemble, matlab.unittest.constraints.IsEqualTo(trueRes, ...
                 'Within', matlab.unittest.constraints.RelativeTolerance(1e-4)))
         end


### PR DESCRIPTION
Make sure that the value of K in the TMFA functions is never lower than the maximum reaction flux value in the system.